### PR TITLE
Added bg of cursorline to cursorcolumn

### DIFF
--- a/colors/neonwave.vim
+++ b/colors/neonwave.vim
@@ -48,6 +48,7 @@ hi Character         ctermfg=207   ctermbg=NONE   cterm=NONE
 hi Conditional       ctermfg=201   ctermbg=NONE   cterm=bold
 hi Comment           ctermfg=244   ctermbg=NONE   cterm=NONE
 hi CursorLine        ctermfg=NONE  ctermbg=235    cterm=NONE
+hi cursorcolumn      ctermfg=NONE  ctermbg=235    cterm=NONE
 hi CursorLineNr      ctermfg=45    ctermbg=235    cterm=bold
 hi Define            ctermfg=61    ctermbg=NONE   cterm=NONE
 hi DefinedName       ctermfg=200   ctermbg=NONE   cterm=NONE


### PR DESCRIPTION
Hi, i noticed that when i use cursorcolumn the background doesn't match the color of cursorline:
![screenshot from 2015-06-25 23 16 50](https://cloud.githubusercontent.com/assets/4595174/8371275/704b3d9a-1b92-11e5-8b10-86e38d5e30a1.png)

this pull request will make both the same color, so is nicer =)
![screenshot from 2015-06-25 23 14 15](https://cloud.githubusercontent.com/assets/4595174/8371286/97923d4a-1b92-11e5-87d6-30007ba41fe7.png)
