### PR TITLE
Add Folding Highlights, Remove from TODO

### DIFF
--- a/TODO
+++ b/TODO
@@ -9,10 +9,8 @@ DiffAdd
 DiffChange
 DiffDelete
 DiffText
-FoldColumn
-Folded
 Ignore
-SpellCap     # YCM says this is also for YcmWarningSection, 
+SpellCap     # YCM says this is also for YcmWarningSection,
              # but I do not extensively use YCM to notice where this lies.
 SpellRare
 SpellLocal

--- a/colors/neonwave.vim
+++ b/colors/neonwave.vim
@@ -58,6 +58,8 @@ hi Error             ctermfg=196   ctermbg=232    cterm=bold
 hi ErrorMsg          ctermfg=196   ctermbg=232    cterm=bold
 hi Exception         ctermfg=201   ctermbg=NONE   cterm=bold
 hi Float             ctermfg=37    ctermbg=NONE   cterm=NONE
+hi FoldColumn        ctermfg=33    ctermbg=233    cterm=NONE
+hi Folded            ctermfg=33    ctermbg=NONE   cterm=NONE
 hi Function          ctermfg=38    ctermbg=NONE   cterm=NONE
 hi Identifier        ctermfg=201   ctermbg=NONE   cterm=NONE
 hi Include           ctermfg=69    ctermbg=NONE   cterm=bold


### PR DESCRIPTION
More muted folding highlights increases the file's 隠然 134%.

**Before**
<img width="500" alt="before" src="https://cloud.githubusercontent.com/assets/515654/8594132/68227256-2681-11e5-941c-90d7cff9277d.png">

**After**
<img width="500" alt="after" src="https://cloud.githubusercontent.com/assets/515654/8594131/671f6332-2681-11e5-9824-43e4621d1302.png">

I use folding quite a lot, so the non-colours were disrupting my advances. However, I am not sure if 134% is enough 隠然 for you. What do you think?